### PR TITLE
DijitWrapper Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,57 @@ Package that provides various bindings to enable interoperability for external l
 
 ## Features
 
-Coming Soon!
+### DijitWrapper
+
+`DijitWrapper` is a mixin class that can convert a Dojo 1 based Dijit and allow it to integrate to the Dojo 2 widgeting system.
+
+The wrapper takes a Dijit constructor function as its input and returns a Dojo 2 widget.  For example, to take the `dijit/Calendar`
+and place it a Dojo 2 `App` widget would look something like this:
+
+```ts
+import * as CalendarDijit from 'dijit/Calendar';
+import DijitWrapper from '@dojo/interop/dijit/DijitWrapper';
+import { v, w } from '@dojo/widget-core/d';
+import WidgetBase from '@dojo/widget-core/WidgetBase';
+
+const Calendar = DijitWrapper(CalendarDijit);
+
+class App extends WidgetBase {
+  private _onCalendarChange = (date: Date) => {
+    console.log('Date selected:', date);
+  }
+
+  render() {
+    return v('div', { key: 'root' }, [
+      w(Calendar, {
+        key: 'calendar1',
+        id: 'calendar1',
+        onChange: this._onCalendarChange
+      })
+    ]);
+  }
+}
+
+export default App;
+```
+
+This would result, when displayed through a projector, the Dijit Calendar which every time the date changed, it would log the new date
+to the console.
+
+It is also possible to use a Dijit container, like `dijit/layout/ContentPane`, but children of a wrapped Dijit widget can only other
+wrapped Dijits.  You cannot place virtual DOM children (node from `v()`) or other non Dijit widgets as children.
+
+The `DijitWrapper` takes an optional second argument, which is the `tagName` that should be used when the widgeting system needs to create a DOM node to root a widget.  By default it uses `div`.
+
+For most existing Dojo 1 Dijits, the typings can be found at [dojo/typings](https://github.com/dojo/typings) and can be installed via npm via `npm install dojo-typings`.  User created Dijits should be able to be used with the `DijitWrapper` though they need to ensure that they adhere to the minimum interface described in the `/dijit/interfaces.d.ts` that is part of this package.
+
+### ReduxInjector
+
+*Coming Soon*
 
 ## How do I use this package?
 
-To use @dojo/interop, install the package using npm:
+To use `@dojo/interop`, install the package using npm:
 
 ```
 npm install @dojo/interop

--- a/README.md
+++ b/README.md
@@ -44,15 +44,14 @@ class App extends WidgetBase {
 export default App;
 ```
 
-This would result, when displayed through a projector, the Dijit Calendar which every time the date changed, it would log the new date
-to the console.
+The result, when displayed through a projector, is a Dijit Calendar which will log the new date to the console every time the date is changed.
 
 It is also possible to use a Dijit container, like `dijit/layout/ContentPane`, but children of a wrapped Dijit widget can only other
-wrapped Dijits.  You cannot place virtual DOM children (node from `v()`) or other non Dijit widgets as children.
+wrapped Dijits.  You cannot place virtual DOM children (nodes from `v()`) or other non Dijit widgets as children.
 
-The `DijitWrapper` takes an optional second argument, which is the `tagName` that should be used when the widgeting system needs to create a DOM node to root a widget.  By default it uses `div`.
+The `DijitWrapper` takes an optional second argument, `tagName`, which should be used when the widgeting system needs to create a DOM node to root a widget.  By default it uses `div`.
 
-For most existing Dojo 1 Dijits, the typings can be found at [dojo/typings](https://github.com/dojo/typings) and can be installed via npm via `npm install dojo-typings`.  User created Dijits should be able to be used with the `DijitWrapper` though they need to ensure that they adhere to the minimum interface described in the `/dijit/interfaces.d.ts` that is part of this package.
+For most existing Dojo 1 Dijits, the TypeScript typings can be found at [dojo/typings](https://github.com/dojo/typings) and can be installed via npm via `npm install dojo-typings`.  User created Dijits may be used with the `DijitWrapper` provide they adhere to the minimum interface described in the `/dijit/interfaces.d.ts` that is part of this package.
 
 ### ReduxInjector
 

--- a/package.json
+++ b/package.json
@@ -25,23 +25,26 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@dojo/widget-core": "next",
     "@dojo/core": "next",
     "@dojo/has": "next",
     "@dojo/i18n": "next",
-    "@dojo/shim": "next"
+    "@dojo/shim": "next",
+    "@dojo/widget-core": "next"
   },
   "devDependencies": {
     "@dojo/interfaces": "next",
     "@dojo/loader": "next",
+    "@dojo/test-extras": "next",
     "@types/chai": "4.0.*",
     "@types/glob": "5.0.*",
     "@types/grunt": "0.4.*",
-    "@types/sinon": "^1.16.31",
+    "@types/jsdom": "^11.0.2",
+    "@types/sinon": "^2.3.4",
     "codecov.io": "0.1.6",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
     "intern": "^3.4.6",
+    "sinon": "^2.3.0",
     "typescript": "~2.4.2"
   },
   "optionalDependencies": {

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -6,6 +6,9 @@ import { afterRender, WidgetBase } from '@dojo/widget-core/WidgetBase';
 import Base from '@dojo/widget-core/meta/Base';
 import { Dijit, DijitConstructor, DijitWrapperProperties, DijitWrapper as DijitWrapperClass } from './interfaces';
 
+/**
+ * An internal meta provider that provides the rendered DOM node on _root_ Dijits
+ */
 class DomNode extends Base {
 	public get(key: string) {
 		this.requireNode(key);
@@ -40,6 +43,7 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 		 * @param params The paramters for the dijit
 		 */
 		private _updateDijit(params: { [param: string]: any; }) {
+			// not null assertion, because this can only be called when `_dijit` is assigned
 			this._dijit!.set(params);
 		}
 

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -1,0 +1,44 @@
+import { v } from '@dojo/widget-core/d';
+import { Constructor, DNode, WidgetProperties } from '@dojo/widget-core/interfaces';
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import Base from '@dojo/widget-core/meta/Base';
+import { Dijit, DijitConstructor, DijitParams } from './interfaces';
+
+class DomNode extends Base {
+	public get(key: string) {
+		this.requireNode(key);
+		return this.nodes.get(key);
+	}
+}
+
+/**
+ * The wrapper class for a wrapped Dojo 1 Dijit
+ */
+export type DijitWrapper<P extends DijitParams> = Constructor<WidgetBase<P & WidgetProperties>>;
+
+/**
+ * Internal `key` constant
+ */
+const key = 'root';
+
+/**
+ * Wrap a Dojo 1 Dijit, so that it can exist inside of the Dojo 2 widgeting system.
+ * @param Dijit The constructor function for the Dijit
+ * @param tagName The tag name that should be used when creating the DOM for the dijit. Defaults to `div`
+ */
+export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D, Partial<D>>, tagName = 'div'): DijitWrapper<Partial<D>> {
+	return class extends WidgetBase<Partial<D>> {
+		private _dijit: D | undefined;
+
+		protected render(): DNode {
+			const node = this.meta(DomNode).get(key);
+			if (node && !this._dijit) {
+				const dijit = this._dijit = new Dijit(this.properties, node);
+				dijit.startup();
+			}
+			return v(tagName, { key }, this.children);
+		}
+	};
+}
+
+export default DijitWrapper;

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -36,7 +36,7 @@ const DEFAULT_KEY = 'root';
 export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagName = 'div'): Constructor<DijitWrapperClass<D>> {
 	class DijitWrapper extends WidgetBase<Partial<D> & DijitWrapperProperties, WNode<DijitWrapperClass<D>>> {
 		private _dijit: D | undefined;
-		private _dijitPlaced = false;
+		private _node: HTMLElement | undefined;
 
 		/**
 		 * Temporary logic until [dojo/widget-core#670](https://github.com/dojo/widget-core/issues/670) is delivered
@@ -58,12 +58,20 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 				this._updateDijit(params);
 			}
 			const dijit = this._dijit!;
-			if (!onInstantiate && !this._dijitPlaced) {
+			if (!onInstantiate) {
 				const node = this.meta(DomNode).get(key);
 				if (node) {
-					dijit.placeAt(node, 'replace');
-					dijit.startup();
-					this._dijitPlaced = true;
+					// We need to accomodate for the node changing, because it is theoretically impossible,
+					// but have been unable to create the right conditions where this would actually occur
+					/* istanbul ignore else */
+					if (!this._node || (this._node !== node)) {
+						dijit.placeAt(node, 'replace');
+						/* istanbul ignore else */
+						if (!this._node) {
+							dijit.startup();
+						}
+						this._node = node;
+					}
 				}
 			}
 

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -31,15 +31,18 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D, Partial
 	return class extends WidgetBase<Partial<D>> {
 		private _dijit: D | undefined;
 
+		private _createDijit(node: HTMLElement) {
+			const dijit = this._dijit = new Dijit(this.properties, node);
+			this.own(createHandle(() => {
+				dijit.destroy();
+				this._dijit = undefined;
+			}));
+		}
+
 		protected render(): DNode {
 			const node = this.meta(DomNode).get(key);
 			if (node && !this._dijit) {
-				const dijit = this._dijit = new Dijit(this.properties, node);
-				dijit.startup();
-				this.own(createHandle(() => {
-					dijit.destroy();
-					this._dijit = undefined;
-				}));
+				this._createDijit(node);
 			}
 			return v(tagName, { key }, this.children);
 		}

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -1,7 +1,7 @@
 import { createHandle } from '@dojo/core/lang';
 import { assign } from '@dojo/shim/object';
 import { isHNode, isWNode, v } from '@dojo/widget-core/d';
-import { Constructor, DNode, WNode } from '@dojo/widget-core/interfaces';
+import { Constructor, DNode, HNode, WNode } from '@dojo/widget-core/interfaces';
 import { afterRender, WidgetBase } from '@dojo/widget-core/WidgetBase';
 import Base from '@dojo/widget-core/meta/Base';
 import { Dijit, DijitConstructor, DijitWrapperProperties, DijitWrapper as DijitWrapperClass } from './interfaces';
@@ -85,7 +85,7 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 		 * @returns The post decorated values
 		 */
 		@afterRender()
-		public decorateChildProperties(result: DNode | DNode[]) {
+		public decorateChildProperties(result: HNode | DNode[]) {
 			if (!this._dijit || !this._dijit.addChild) {
 				return result;
 			}
@@ -102,7 +102,7 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 				}
 			}
 
-			Array.isArray(result) ? result.forEach(decorateChild) : isHNode(result) && result.children.forEach(decorateChild);
+			Array.isArray(result) ? result.forEach(decorateChild) : result.children.forEach(decorateChild);
 
 			return result;
 		}

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -1,6 +1,6 @@
 import { createHandle } from '@dojo/core/lang';
 import { assign } from '@dojo/shim/object';
-import { isHNode, isWNode, v } from '@dojo/widget-core/d';
+import { isWNode, v } from '@dojo/widget-core/d';
 import { Constructor, DNode, HNode, WNode } from '@dojo/widget-core/interfaces';
 import { afterRender, WidgetBase } from '@dojo/widget-core/WidgetBase';
 import Base from '@dojo/widget-core/meta/Base';

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -1,3 +1,4 @@
+import { createHandle } from '@dojo/core/lang';
 import { v } from '@dojo/widget-core/d';
 import { Constructor, DNode, WidgetProperties } from '@dojo/widget-core/interfaces';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
@@ -35,6 +36,10 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D, Partial
 			if (node && !this._dijit) {
 				const dijit = this._dijit = new Dijit(this.properties, node);
 				dijit.startup();
+				this.own(createHandle(() => {
+					dijit.destroy();
+					this._dijit = undefined;
+				}));
 			}
 			return v(tagName, { key }, this.children);
 		}

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -40,7 +40,7 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 
 		/**
 		 * Temporary logic until [dojo/widget-core#670](https://github.com/dojo/widget-core/issues/670) is delivered
-		 * @param params The paramters for the dijit
+		 * @param params The paramters for the Dijit
 		 */
 		private _updateDijit(params: { [param: string]: any; }) {
 			// not null assertion, because this can only be called when `_dijit` is assigned
@@ -61,7 +61,7 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 			if (!onInstantiate) {
 				const node = this.meta(DomNode).get(key);
 				if (node) {
-					// We need to accomodate for the node changing, because it is theoretically impossible,
+					// We need to accommodate for the node changing, because it is theoretically impossible,
 					// but have been unable to create the right conditions where this would actually occur
 					/* istanbul ignore else */
 					if (!this._node || (this._node !== node)) {

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -1,9 +1,10 @@
 import { createHandle } from '@dojo/core/lang';
-import { v } from '@dojo/widget-core/d';
-import { Constructor, DNode, WidgetProperties } from '@dojo/widget-core/interfaces';
-import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { assign } from '@dojo/shim/object';
+import { isHNode, isWNode, v } from '@dojo/widget-core/d';
+import { Constructor, DNode, WNode } from '@dojo/widget-core/interfaces';
+import { afterRender, WidgetBase } from '@dojo/widget-core/WidgetBase';
 import Base from '@dojo/widget-core/meta/Base';
-import { Dijit, DijitConstructor, DijitParams } from './interfaces';
+import { Dijit, DijitConstructor, DijitWrapperProperties, DijitWrapper as DijitWrapperClass } from './interfaces';
 
 class DomNode extends Base {
 	public get(key: string) {
@@ -13,40 +14,89 @@ class DomNode extends Base {
 }
 
 /**
- * The wrapper class for a wrapped Dojo 1 Dijit
+ * Used to make it easier to peel off some values when spreading the `widget.properties` to dijit params
  */
-export type DijitWrapper<P extends DijitParams> = Constructor<WidgetBase<P & WidgetProperties>>;
+interface DijitProperties extends DijitWrapperProperties {
+	[param: string]: any;
+}
 
 /**
  * Internal `key` constant
  */
-const key = 'root';
+const DEFAULT_KEY = 'root';
 
 /**
  * Wrap a Dojo 1 Dijit, so that it can exist inside of the Dojo 2 widgeting system.
  * @param Dijit The constructor function for the Dijit
- * @param tagName The tag name that should be used when creating the DOM for the dijit. Defaults to `div`
+ * @param tagName The tag name that should be used when creating the DOM for the dijit. Defaults to `div`.
  */
-export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D, Partial<D>>, tagName = 'div'): DijitWrapper<Partial<D>> {
-	return class extends WidgetBase<Partial<D>> {
+export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagName = 'div'): Constructor<DijitWrapperClass<D>> {
+	class DijitWrapper extends WidgetBase<Partial<D> & DijitWrapperProperties, WNode<DijitWrapperClass<D>>> {
 		private _dijit: D | undefined;
+		private _dijitPlaced = false;
 
-		private _createDijit(node: HTMLElement) {
-			const dijit = this._dijit = new Dijit(this.properties, node);
-			this.own(createHandle(() => {
-				dijit.destroy();
-				this._dijit = undefined;
-			}));
+		/**
+		 * Temporary logic until [dojo/widget-core#670](https://github.com/dojo/widget-core/issues/670) is delivered
+		 * @param params The paramters for the dijit
+		 */
+		private _updateDijit(params: { [param: string]: any; }) {
+			this._dijit!.set(params);
 		}
 
-		protected render(): DNode {
-			const node = this.meta(DomNode).get(key);
-			if (node && !this._dijit) {
-				this._createDijit(node);
+		protected render() {
+			const { bind, key = DEFAULT_KEY, onInstantiate, registry, ...params } = this.properties as DijitProperties;
+			if (!this._dijit) {
+				const dijit = this._dijit = new Dijit(params as Partial<D>);
+				onInstantiate && onInstantiate(dijit);
+				this.own(createHandle(() => dijit.destroy(true)));
 			}
-			return v(tagName, { key }, this.children);
+			else {
+				this._updateDijit(params);
+			}
+			const dijit = this._dijit!;
+			if (!onInstantiate && !this._dijitPlaced) {
+				const node = this.meta(DomNode).get(key);
+				if (node) {
+					dijit.placeAt(node, 'replace');
+					dijit.startup();
+					this._dijitPlaced = true;
+				}
+			}
+
+			return onInstantiate ? this.children : v(tagName, { key }, this.children);
+		}
+
+		/**
+		 * Decorates the properties of children, injecting an `onInstantiate` callback so that they add themselves to
+		 * their enlosing parent.
+		 * @param result The render returned, ready to be decorated
+		 * @returns The post decorated values
+		 */
+		@afterRender()
+		public decorateChildProperties(result: DNode | DNode[]) {
+			if (!this._dijit || !this._dijit.addChild) {
+				return result;
+			}
+			const dijit = this._dijit;
+			const addChild = dijit.addChild!;
+
+			function decorateChild(child: DNode, idx: number) {
+				if (isWNode(child) && !(child.properties as DijitWrapperProperties).onInstantiate) {
+					assign(child.properties, {
+						onInstantiate(instance: Dijit) {
+							addChild.call(dijit, instance, idx);
+						}
+					});
+				}
+			}
+
+			Array.isArray(result) ? result.forEach(decorateChild) : isHNode(result) && result.children.forEach(decorateChild);
+
+			return result;
 		}
 	};
+
+	return DijitWrapper;
 }
 
 export default DijitWrapper;

--- a/src/dijit/interfaces.d.ts
+++ b/src/dijit/interfaces.d.ts
@@ -1,0 +1,35 @@
+/**
+ * A basic interface for Dojo 1 Dijit instances
+ */
+export interface Dijit {
+	/**
+	 * This is the _root_ of a Dijit instance, which maybe different than the `srcNodeRef`
+	 */
+	domNode: HTMLElement;
+
+	/**
+	 * A reference to the origina DOM node
+	 */
+	srcNodeRef: HTMLElement;
+
+	/**
+	 * Perform cleanup activities related to the Dijit instance
+	 */
+	destroy(preserveDom?: boolean): void;
+
+	/**
+	 * Complete the Dijit lifecycle on an already existing DOM node
+	 */
+	startup(): void;
+}
+
+/**
+ * A generic interface for Dojo 1 Dijit constructor functions
+ */
+export interface DijitConstructor<T extends Dijit, P extends DijitParams> {
+	new (params: DijitParams, srcNodeRef: string | Node): T;
+}
+
+export interface DijitParams {
+	[param: string]: any;
+}

--- a/src/dijit/interfaces.d.ts
+++ b/src/dijit/interfaces.d.ts
@@ -16,12 +16,12 @@ export interface Dijit {
 	destroy(preserveDom?: boolean): void;
 
 	/**
-	 * Used to insert a _root_ dijit into the DOM created by the projector
+	 * Used to insert a _root_ Dijit into the DOM created by the projector
 	 */
 	placeAt(reference: Node | string | DocumentFragment, position?: string | number): this;
 
 	/**
-	 * Used to set a param bag on an already instantiated dijit when updating properties
+	 * Used to set a param bag on an already instantiated Dijit when updating properties
 	 */
 	set(values: { [param: string]: any }): this;
 
@@ -43,8 +43,8 @@ export interface DijitConstructor<T extends Dijit> {
  */
 export interface DijitWrapperProperties extends WidgetProperties {
 	/**
-	 * A property that if present causes the DijitWrapper to call method with the instantiated dijit, instead of
-	 * attempting to generate a DOM node to attach the dijit to.  Designed to be injected by a parent dijit so it
+	 * A property that if present causes the DijitWrapper to call method with the instantiated `dijit`, instead of
+	 * attempting to generate a DOM node to attach the `dijit` to.  Designed to be injected by a parent `dijit` so it
 	 * can append the child to itself.
 	 */
 	onInstantiate?(dijit: Dijit): void;

--- a/src/dijit/interfaces.d.ts
+++ b/src/dijit/interfaces.d.ts
@@ -1,21 +1,29 @@
+import { DNode, WidgetProperties, WNode } from '@dojo/widget-core/interfaces';
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+
 /**
  * A basic interface for Dojo 1 Dijit instances
  */
 export interface Dijit {
 	/**
-	 * This is the _root_ of a Dijit instance, which maybe different than the `srcNodeRef`
+	 * Available in certain container widgets, used by the wrapper to append children to parent
 	 */
-	domNode: HTMLElement;
-
-	/**
-	 * A reference to the origina DOM node
-	 */
-	srcNodeRef: HTMLElement;
+	addChild?(child: object, insertIndex?: number): void;
 
 	/**
 	 * Perform cleanup activities related to the Dijit instance
 	 */
 	destroy(preserveDom?: boolean): void;
+
+	/**
+	 * Used to insert a _root_ dijit into the DOM created by the projector
+	 */
+	placeAt(reference: Node | string | DocumentFragment, position?: string | number): this;
+
+	/**
+	 * Used to set a param bag on an already instantiated dijit when updating properties
+	 */
+	set(values: { [param: string]: any }): this;
 
 	/**
 	 * Complete the Dijit lifecycle on an already existing DOM node
@@ -26,10 +34,26 @@ export interface Dijit {
 /**
  * A generic interface for Dojo 1 Dijit constructor functions
  */
-export interface DijitConstructor<T extends Dijit, P extends DijitParams> {
-	new (params: DijitParams, srcNodeRef: string | Node): T;
+export interface DijitConstructor<T extends Dijit> {
+	new (params: Partial<T>, srcNodeRef?: string | Node): T;
 }
 
-export interface DijitParams {
-	[param: string]: any;
+/**
+ * Additional DijitWrapperProperties
+ */
+export interface DijitWrapperProperties extends WidgetProperties {
+	/**
+	 * A property that if present causes the DijitWrapper to call method with the instantiated dijit, instead of
+	 * attempting to generate a DOM node to attach the dijit to.  Designed to be injected by a parent dijit so it
+	 * can append the child to itself.
+	 */
+	onInstantiate?(dijit: Dijit): void;
+}
+
+export class DijitWrapper<D extends Dijit> extends WidgetBase<Partial<D> & DijitWrapperProperties, WNode<DijitWrapper<Dijit>>> {
+	/**
+	 * A method that is decorated to be called after the render that will inject `onInstantiate` into children `DijitWrapper`s
+	 * @param result The render result
+	 */
+	public decorateChildProperties(result: DNode | DNode[]): DNode | DNode[];
 }

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,2 +1,3 @@
 import './main';
+import './dijit/all';
 import './redux/ReduxInjector';

--- a/tests/unit/dijit/DijitWrapper.ts
+++ b/tests/unit/dijit/DijitWrapper.ts
@@ -1,0 +1,37 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import DijitWrapper from '../../../src/dijit/DijitWrapper';
+
+import { w } from '@dojo/widget-core/d';
+
+registerSuite({
+	name: 'dijit/DijitWrapper',
+
+	'wrap a Dijit'() {
+		class MockDijit {
+			public id: string;
+			public srcNodeRef: HTMLElement;
+			public domNode: HTMLElement;
+
+			constructor(params: Object, srcRefNode?: string | Node) {
+				//
+			}
+
+			public destroy(preserveDom = true) {
+				//
+			}
+
+			public startup() {
+				//
+			}
+		}
+
+		const MockDijitWidget = DijitWrapper(MockDijit);
+
+		const wnode = w(MockDijitWidget, {
+			id: 'foo'
+		});
+
+		console.log(wnode);
+	}
+});

--- a/tests/unit/dijit/DijitWrapper.ts
+++ b/tests/unit/dijit/DijitWrapper.ts
@@ -1,5 +1,4 @@
 import * as registerSuite from 'intern!object';
-// import * as assert from 'intern/chai!assert';
 import harness from '@dojo/test-extras/harness';
 import { stub } from 'sinon';
 import { compareProperty } from '@dojo/test-extras/support/d';
@@ -21,7 +20,10 @@ class MockDijit {
 
 	public destroy(preserveDom = true) { }
 
-	public placeAt() {
+	public placeAt(node: HTMLElement, reference?: string | number) {
+		if (reference !== 'replace') {
+			throw new Error('Expected "replace" as reference');
+		}
 		return this;
 	}
 

--- a/tests/unit/dijit/DijitWrapper.ts
+++ b/tests/unit/dijit/DijitWrapper.ts
@@ -1,49 +1,108 @@
 import * as registerSuite from 'intern!object';
 // import * as assert from 'intern/chai!assert';
+import harness from '@dojo/test-extras/harness';
+import { stub } from 'sinon';
+import { compareProperty } from '@dojo/test-extras/support/d';
 import DijitWrapper from '../../../src/dijit/DijitWrapper';
 
-import { w } from '@dojo/widget-core/d';
+import { v, w } from '@dojo/widget-core/d';
+import WidgetRegistry from '@dojo/widget-core/WidgetRegistry';
+
+const isRegistry = compareProperty((value) => {
+	return value instanceof WidgetRegistry;
+});
+
+class MockDijit {
+	public id: string;
+	public srcNodeRef: HTMLElement;
+	public domNode: HTMLElement;
+
+	constructor(params: Object, srcRefNode?: string | Node) { }
+
+	public destroy(preserveDom = true) { }
+
+	public placeAt() {
+		return this;
+	}
+
+	public set() {
+		return this;
+	}
+
+	public startup() { }
+}
+
+class ContainerMockDijit extends MockDijit {
+	public addChild() { }
+}
 
 registerSuite({
 	name: 'dijit/DijitWrapper',
 
-	'wrap a Dijit'() {
-		class MockDijit {
-			public id: string;
-			public srcNodeRef: HTMLElement;
-			public domNode: HTMLElement;
+	'a wrapped dijit should create an empty vnode'() {
+		const widget = harness(DijitWrapper(MockDijit));
+		widget.expectRender(v('div', { key: 'root' }, []), 'should have created an empty node');
+		widget.destroy();
+	},
 
-			constructor(params: Object, srcRefNode?: string | Node) {
-				//
-			}
-
-			public addChild() {
-				//
-			}
-
-			public destroy(preserveDom = true) {
-				//
-			}
-
-			public placeAt() {
-				return this;
-			}
-
-			public set() {
-				return this;
-			}
-
-			public startup() {
-				//
-			}
-		}
-
+	'a wrapped dijit with children dijit should render children'() {
+		const ContainerDijitWidget = DijitWrapper(ContainerMockDijit);
 		const MockDijitWidget = DijitWrapper(MockDijit);
+		const widget = harness(ContainerDijitWidget);
+		widget.setChildren([
+			w(MockDijitWidget, { key: 'foo' }),
+			w(MockDijitWidget, { key: 'bar' }),
+			w(MockDijitWidget, { key: 'baz' })
+		]);
 
-		const wnode = w(MockDijitWidget, {
-			id: 'foo'
-		}, [ w(MockDijitWidget, {}) ]);
+		widget.expectRender(v('div', { key: 'root' }, [
+			w(MockDijitWidget, { key: 'foo', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any),
+			w(MockDijitWidget, { key: 'bar', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any),
+			w(MockDijitWidget, { key: 'baz', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any)
+		]));
 
-		console.log(wnode);
+		const dijit = new MockDijit({});
+
+		widget.callListener('onInstantiate', {
+			args: [ dijit ],
+			key: 'foo'
+		});
+		widget.destroy();
+	},
+
+	'a wrapped dijit should render supplied key'() {
+		const widget = harness(DijitWrapper(MockDijit));
+		widget.setProperties({
+			key: 'foo'
+		});
+		widget.expectRender(v('div', { key: 'foo' }, []), 'should have created an empty node');
+		widget.destroy();
+	},
+
+	'a contained dijit with children should render flat array of its children'() {
+		const ContainerDijitWidget = DijitWrapper(ContainerMockDijit);
+		const MockDijitWidget = DijitWrapper(MockDijit);
+		const widget = harness(ContainerDijitWidget);
+		const onInstantiate = stub();
+		widget.setProperties({
+			onInstantiate
+		});
+		widget.setChildren([
+			w(MockDijitWidget, { key: 'foo' }),
+			w(MockDijitWidget, { key: 'bar' }),
+			w(MockDijitWidget, { key: 'baz' })
+		]);
+
+		widget.expectRender([
+			w(MockDijitWidget, { key: 'foo', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any),
+			w(MockDijitWidget, { key: 'bar', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any),
+			w(MockDijitWidget, { key: 'baz', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any)
+		]);
+		widget.destroy();
+	},
+
+	'a dijit wrapper should use tag name provided when rendering'() {
+		const widget = harness(DijitWrapper(MockDijit, 'span'));
+		widget.expectRender(v('span', { key: 'root' }, []));
 	}
 });

--- a/tests/unit/dijit/DijitWrapper.ts
+++ b/tests/unit/dijit/DijitWrapper.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern!object';
-import * as assert from 'intern/chai!assert';
+// import * as assert from 'intern/chai!assert';
 import DijitWrapper from '../../../src/dijit/DijitWrapper';
 
 import { w } from '@dojo/widget-core/d';
@@ -17,8 +17,20 @@ registerSuite({
 				//
 			}
 
+			public addChild() {
+				//
+			}
+
 			public destroy(preserveDom = true) {
 				//
+			}
+
+			public placeAt() {
+				return this;
+			}
+
+			public set() {
+				return this;
 			}
 
 			public startup() {
@@ -30,7 +42,7 @@ registerSuite({
 
 		const wnode = w(MockDijitWidget, {
 			id: 'foo'
-		});
+		}, [ w(MockDijitWidget, {}) ]);
 
 		console.log(wnode);
 	}

--- a/tests/unit/dijit/all.ts
+++ b/tests/unit/dijit/all.ts
@@ -1,1 +1,2 @@
+import '@dojo/test-extras/support/loadJsdom';
 import './DijitWrapper';

--- a/tests/unit/dijit/all.ts
+++ b/tests/unit/dijit/all.ts
@@ -1,0 +1,1 @@
+import './DijitWrapper';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"declaration": false,
+		"declaration": true,
 		"experimentalDecorators": true,
 		"module": "umd",
 		"moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"experimentalDecorators": true,
 		"module": "umd",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR provides a way to wrap a Dojo 1 Dijit so that it can be included as part of a Dojo 2 widget rendering process.

Wrapped Dijits can only have other wrapped Dijits as their children.  This is because while the widget system still manages the properties on the Dijit instances, after it encounters the first Dijit in a tree it will not render additional DOM.

* [x] - Forgot to update the README.
* [x] - Need to deal with if the root DOM node changes.

Resolves #3
