### PR TITLE
Do not preserve DOM with DijitWrapper

### DIFF
--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -52,7 +52,7 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 			if (!this._dijit) {
 				const dijit = this._dijit = new Dijit(params as Partial<D>);
 				onInstantiate && onInstantiate(dijit);
-				this.own(createHandle(() => dijit.destroy(true)));
+				this.own(createHandle(() => dijit.destroy()));
 			}
 			else {
 				this._updateDijit(params);

--- a/tests/unit/dijit/DijitWrapper.ts
+++ b/tests/unit/dijit/DijitWrapper.ts
@@ -1,4 +1,5 @@
 import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import harness from '@dojo/test-extras/harness';
 import { stub } from 'sinon';
 import { compareProperty } from '@dojo/test-extras/support/d';
@@ -11,6 +12,8 @@ const isRegistry = compareProperty((value) => {
 	return value instanceof WidgetRegistry;
 });
 
+let lastDestroyPreserveDom: boolean;
+
 class MockDijit {
 	public id: string;
 	public srcNodeRef: HTMLElement;
@@ -18,7 +21,9 @@ class MockDijit {
 
 	constructor(params: Object, srcRefNode?: string | Node) { }
 
-	public destroy(preserveDom = true) { }
+	public destroy(preserveDom = false) {
+		lastDestroyPreserveDom = false;
+	}
 
 	public placeAt(node: HTMLElement, reference?: string | number) {
 		if (reference !== 'replace') {
@@ -70,6 +75,7 @@ registerSuite({
 			key: 'foo'
 		});
 		widget.destroy();
+		assert.isFalse(lastDestroyPreserveDom, 'wrapper should not preserve Dijit DOM');
 	},
 
 	'a wrapped dijit should render supplied key'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

Does not preserve DOM when destroying a wrapped widget.

Resolves #6
