### PR TITLE
Add static references for Dijit constructor

### DIFF
--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -50,7 +50,7 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 		protected render() {
 			const { bind, key = DEFAULT_KEY, onInstantiate, registry, ...params } = this.properties as DijitProperties;
 			if (!this._dijit) {
-				const dijit = this._dijit = new Dijit(params as Partial<D>);
+				const dijit = this._dijit = new DijitWrapper.Dijit(params as Partial<D>);
 				onInstantiate && onInstantiate(dijit);
 				this.own(createHandle(() => dijit.destroy()));
 			}
@@ -75,7 +75,7 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 				}
 			}
 
-			return onInstantiate ? this.children : v(tagName, { key }, this.children);
+			return onInstantiate ? this.children : v(DijitWrapper.tagName, { key }, this.children);
 		}
 
 		/**
@@ -106,6 +106,9 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 
 			return result;
 		}
+
+		public static readonly Dijit = Dijit;
+		public static readonly tagName = tagName;
 	};
 
 	return DijitWrapper;

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -47,6 +47,16 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 			this._dijit!.set(params);
 		}
 
+		/**
+		 * A reference to the Dijit constructor function for this class
+		 */
+		public static readonly Dijit = Dijit;
+
+		/**
+		 * The tag name to be used by this class when constructing a virutal DOM node for a Dijit
+		 */
+		public static readonly tagName = tagName;
+
 		protected render() {
 			const { bind, key = DEFAULT_KEY, onInstantiate, registry, ...params } = this.properties as DijitProperties;
 			if (!this._dijit) {
@@ -106,9 +116,6 @@ export function DijitWrapper<D extends Dijit>(Dijit: DijitConstructor<D>, tagNam
 
 			return result;
 		}
-
-		public static readonly Dijit = Dijit;
-		public static readonly tagName = tagName;
 	};
 
 	return DijitWrapper;

--- a/src/dijit/interfaces.d.ts
+++ b/src/dijit/interfaces.d.ts
@@ -56,4 +56,14 @@ export class DijitWrapper<D extends Dijit> extends WidgetBase<Partial<D> & Dijit
 	 * @param result The render result
 	 */
 	public decorateChildProperties(result: DNode | DNode[]): DNode | DNode[];
+
+	/**
+	 * A reference to the constructor function that this `DijitWrapper` uses to construct new Dijit instances
+	 */
+	public static readonly Dijit: DijitConstructor<Dijit>;
+
+	/**
+	 * The tag name that this `DijitWrapper` will use when generating a DOM stub if required
+	 */
+	public static readonly tagName: string;
 }

--- a/tests/unit/dijit/DijitWrapper.ts
+++ b/tests/unit/dijit/DijitWrapper.ts
@@ -106,5 +106,13 @@ registerSuite({
 	'a dijit wrapper should use tag name provided when rendering'() {
 		const widget = harness(DijitWrapper(MockDijit, 'span'));
 		widget.expectRender(v('span', { key: 'root' }, []));
+	},
+
+	'mixed in classes hold reference to Dijit constructor and tagName'() {
+		// IE11 has some strange GC behaviours which sometimes deferences the constructor, thereby holding a
+		// direct reference should avoid this issue.  See: https://github.com/dojo/interop/issues/10
+		const DijitWidget = DijitWrapper(MockDijit, 'span');
+		assert.strictEqual((DijitWidget as any).Dijit, MockDijit, 'The constructor should equal the passed constructor');
+		assert.strictEqual((DijitWidget as any).tagName, 'span', 'The tag name should equal the passed tag name');
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

By holding static references on the class object, it appears to stop IE11 from doing mis-appropriate GC on arguments passed the mixin function.  Gotta love browser inconsistency.

Resolves #10
