### PR TITLE
Updates based on widget-core changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@dojo/core": "beta2",
-    "@dojo/has": "beta2",
-    "@dojo/i18n": "beta2",
-    "@dojo/shim": "beta2",
-    "@dojo/widget-core": "beta2"
+    "@dojo/core": "next",
+    "@dojo/has": "next",
+    "@dojo/i18n": "next",
+    "@dojo/shim": "next",
+    "@dojo/widget-core": "next"
   },
   "devDependencies": {
-    "@dojo/interfaces": "beta2",
-    "@dojo/loader": "beta2",
-    "@dojo/test-extras": "beta2",
+    "@dojo/interfaces": "next",
+    "@dojo/loader": "next",
+    "@dojo/test-extras": "next",
     "@types/chai": "4.0.*",
     "@types/glob": "5.0.*",
     "@types/grunt": "0.4.*",

--- a/src/dijit/DijitWrapper.ts
+++ b/src/dijit/DijitWrapper.ts
@@ -2,7 +2,8 @@ import { createHandle } from '@dojo/core/lang';
 import { assign } from '@dojo/shim/object';
 import { isWNode, v } from '@dojo/widget-core/d';
 import { Constructor, DNode, HNode, WNode } from '@dojo/widget-core/interfaces';
-import { afterRender, WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import afterRender from '@dojo/widget-core/decorators/afterRender';
 import Base from '@dojo/widget-core/meta/Base';
 import { Dijit, DijitConstructor, DijitWrapperProperties, DijitWrapper as DijitWrapperClass } from './interfaces';
 
@@ -10,9 +11,8 @@ import { Dijit, DijitConstructor, DijitWrapperProperties, DijitWrapper as DijitW
  * An internal meta provider that provides the rendered DOM node on _root_ Dijits
  */
 class DomNode extends Base {
-	public get(key: string) {
-		this.requireNode(key);
-		return this.nodes.get(key);
+	public get(key: string | number) {
+		return this.getNode(key);
 	}
 }
 

--- a/src/redux/ReduxInjector.ts
+++ b/src/redux/ReduxInjector.ts
@@ -1,16 +1,10 @@
 import { Store } from 'redux';
-import { Base } from '@dojo/widget-core/Injector';
+import { Injector } from '@dojo/widget-core/Injector';
 
 /**
  * Injector for redux store
  */
-export class ReduxInjector<S = any> extends Base<Store<S>> {
-
-	/**
-	 * Injected redux store
-	 */
-	protected store: Store<S>;
-
+export class ReduxInjector<S = any> extends Injector<Store<S>> {
 	/**
 	 * Sets the store and attaches the injectors invalidate to the redux
 	 * stores bind.
@@ -18,19 +12,17 @@ export class ReduxInjector<S = any> extends Base<Store<S>> {
 	 * @param store The store for the injector
 	 */
 	constructor(store: Store<S>) {
-		super();
-		this.store = store;
-		this.store.subscribe(this.invalidate.bind(this));
+		super(store);
+		store.subscribe(() => {
+			this.emit({ type: 'invalidated' });
+		});
 	}
 
 	/**
-	 * Returns the value to be injected, in this case the Store
-	 * that was passed when creating the Injector.
-	 *
-	 * @returns Returns the store
+	 * Stores cannot be set on instances of `ReduxInjector`.
 	 */
-	public toInject(): Store<S> {
-		return this.store;
+	public set(): never {
+		throw new TypeError('Cannot perform .set() on ReduxInjector');
 	}
 }
 

--- a/tests/unit/dijit/DijitWrapper.ts
+++ b/tests/unit/dijit/DijitWrapper.ts
@@ -2,15 +2,9 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import harness from '@dojo/test-extras/harness';
 import { stub } from 'sinon';
-import { compareProperty } from '@dojo/test-extras/support/d';
 import DijitWrapper from '../../../src/dijit/DijitWrapper';
 
 import { v, w } from '@dojo/widget-core/d';
-import WidgetRegistry from '@dojo/widget-core/WidgetRegistry';
-
-const isRegistry = compareProperty((value) => {
-	return value instanceof WidgetRegistry;
-});
 
 let lastDestroyPreserveDom: boolean;
 
@@ -63,9 +57,9 @@ registerSuite({
 		]);
 
 		widget.expectRender(v('div', { key: 'root' }, [
-			w(MockDijitWidget, { key: 'foo', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any),
-			w(MockDijitWidget, { key: 'bar', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any),
-			w(MockDijitWidget, { key: 'baz', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any)
+			w(MockDijitWidget, { key: 'foo', onInstantiate: widget.listener } as any),
+			w(MockDijitWidget, { key: 'bar', onInstantiate: widget.listener } as any),
+			w(MockDijitWidget, { key: 'baz', onInstantiate: widget.listener } as any)
 		]));
 
 		const dijit = new MockDijit({});
@@ -102,9 +96,9 @@ registerSuite({
 		]);
 
 		widget.expectRender([
-			w(MockDijitWidget, { key: 'foo', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any),
-			w(MockDijitWidget, { key: 'bar', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any),
-			w(MockDijitWidget, { key: 'baz', defaultRegistry: isRegistry , onInstantiate: widget.listener } as any)
+			w(MockDijitWidget, { key: 'foo', onInstantiate: widget.listener } as any),
+			w(MockDijitWidget, { key: 'bar', onInstantiate: widget.listener } as any),
+			w(MockDijitWidget, { key: 'baz', onInstantiate: widget.listener } as any)
 		]);
 		widget.destroy();
 	},

--- a/tests/unit/redux/ReduxInjector.ts
+++ b/tests/unit/redux/ReduxInjector.ts
@@ -15,9 +15,16 @@ registerSuite({
 		store.dispatch({ type: 'TEST' });
 		assert.isTrue(injectorInvalidated);
 	},
-	toInject() {
+	get() {
 		const store = createStore((state) => state);
 		const injector = new ReduxInjector(store);
-		assert.strictEqual(injector.toInject(), store);
+		assert.strictEqual(injector.get(), store);
+	},
+	set() {
+		const store = createStore((state) => state);
+		const injector = new ReduxInjector(store);
+		assert.throws(() => {
+			injector.set();
+		}, TypeError, 'Cannot perform .set() on ReduxInjector');
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR fixes breaking changes introduced in `widget-core`.

Because of this, the API for `ReduxInjector` removes `.toInject()` which is replaced by `.get()`.