### PR TITLE
Allow extra options to be passed to ReduxInjector

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ For most existing Dojo 1 Dijits, the TypeScript typings can be found at [dojo/ty
 
 ### ReduxInjector
 
-`ReduxInjector` can be used to bind a redux store and Dojo 2 widgets using the `registry`.
+`ReduxInjector` can be used to bind a redux store and Dojo 2 widgets using the `registry`. The value returned by `getProperties` is an object containing two properties:
+
+* `store` - the actual Redux store passed as the first argument to the `ReduxInjector` constructor.
+* `extraOptions` - an additional options object that can be passed as an optional second argument to the `ReduxInjector` constructor.
 
 An injector can be defined in the registry, which is then provided to the `Projector` as one of its properties. This is demonstrated in the example below.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/interop",
-  "version": "0.2.0",
+  "version": "0.2.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/redux/ReduxInjector.ts
+++ b/src/redux/ReduxInjector.ts
@@ -1,18 +1,24 @@
 import { Store } from 'redux';
 import { Injector } from '@dojo/widget-core/Injector';
 
+export interface ReduxInjectorPayload<S, O> {
+	extraOptions?: O;
+	store: Store<S>;
+}
+
 /**
  * Injector for redux store
  */
-export class ReduxInjector<S = any> extends Injector<Store<S>> {
+export class ReduxInjector<S = any, O = any> extends Injector<ReduxInjectorPayload<S, O>> {
 	/**
 	 * Sets the store and attaches the injectors invalidate to the redux
 	 * stores bind.
 	 *
 	 * @param store The store for the injector
+	 * @param extraOptions Additional options returned alongside the store with `getProperties`
 	 */
-	constructor(store: Store<S>) {
-		super(store);
+	constructor(store: Store<S>, extraOptions?: O) {
+		super({ store, extraOptions });
 		store.subscribe(() => {
 			this.emit({ type: 'invalidate' });
 		});

--- a/src/redux/ReduxInjector.ts
+++ b/src/redux/ReduxInjector.ts
@@ -2,8 +2,8 @@ import { Store } from 'redux';
 import { Injector } from '@dojo/widget-core/Injector';
 
 export interface ReduxInjectorPayload<S, O> {
-	extraOptions?: O;
 	store: Store<S>;
+	extraOptions?: O;
 }
 
 /**

--- a/tests/unit/redux/ReduxInjector.ts
+++ b/tests/unit/redux/ReduxInjector.ts
@@ -16,8 +16,9 @@ registerSuite('ReduxInjector', {
 	},
 	get() {
 		const store = createStore((state) => state);
-		const injector = new ReduxInjector(store);
-		assert.strictEqual(injector.get(), store);
+		const extraOptions = {};
+		const injector = new ReduxInjector(store, extraOptions);
+		assert.deepEqual(injector.get(), { store, extraOptions });
 	},
 	set() {
 		const store = createStore((state) => state);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Updates `ReduxInjector` to allow an optional second argument of options that will be included with the `getProperties()` payload. As such, `getProperties` no longer returns the Redux store directly, but instead returns an object with `store` and `extraOptions` properties.

Resolves #16 
